### PR TITLE
Adicionar fallback público para taxas de conversão

### DIFF
--- a/script.js
+++ b/script.js
@@ -11,12 +11,39 @@ async function fetchCurrencies() {
     return await response.json();
   } catch (error) {
     console.error('Erro ao buscar moedas:', error);
-    // Lista de fallback mínima
+    // Lista de fallback com moedas populares suportadas pela Wise
     return [
-      { code: 'USD', name: 'US Dollar' },
-      { code: 'EUR', name: 'Euro' },
+      { code: 'AED', name: 'Dirham dos Emirados Árabes Unidos' },
+      { code: 'ARS', name: 'Peso Argentino' },
+      { code: 'AUD', name: 'Dólar Australiano' },
       { code: 'BRL', name: 'Real Brasileiro' },
+      { code: 'CAD', name: 'Dólar Canadense' },
+      { code: 'CHF', name: 'Franco Suíço' },
       { code: 'CLP', name: 'Peso Chileno' },
+      { code: 'CNY', name: 'Yuan Chinês' },
+      { code: 'COP', name: 'Peso Colombiano' },
+      { code: 'CZK', name: 'Coroa Checa' },
+      { code: 'DKK', name: 'Coroa Dinamarquesa' },
+      { code: 'EUR', name: 'Euro' },
+      { code: 'GBP', name: 'Libra Esterlina' },
+      { code: 'HKD', name: 'Dólar de Hong Kong' },
+      { code: 'HUF', name: 'Forint Húngaro' },
+      { code: 'ILS', name: 'Novo Shekel Israelense' },
+      { code: 'INR', name: 'Rupia Indiana' },
+      { code: 'JPY', name: 'Iene Japonês' },
+      { code: 'MXN', name: 'Peso Mexicano' },
+      { code: 'NOK', name: 'Coroa Norueguesa' },
+      { code: 'NZD', name: 'Dólar Neozelandês' },
+      { code: 'PEN', name: 'Sol Peruano' },
+      { code: 'PLN', name: 'Zloty Polonês' },
+      { code: 'RON', name: 'Leu Romeno' },
+      { code: 'SEK', name: 'Coroa Sueca' },
+      { code: 'SGD', name: 'Dólar de Singapura' },
+      { code: 'THB', name: 'Baht Tailandês' },
+      { code: 'TRY', name: 'Lira Turca' },
+      { code: 'USD', name: 'Dólar Americano' },
+      { code: 'UYU', name: 'Peso Uruguaio' },
+      { code: 'ZAR', name: 'Rand Sul-Africano' },
     ];
   }
 }
@@ -24,7 +51,8 @@ async function fetchCurrencies() {
 function popularMoedas(moedas) {
   const de = document.getElementById('fromCurrency');
   const para = document.getElementById('toCurrency');
-  moedas.forEach((m) => {
+  const listaOrdenada = [...moedas].sort((a, b) => a.code.localeCompare(b.code));
+  listaOrdenada.forEach((m) => {
     const opt = document.createElement('option');
     opt.value = m.code;
     opt.textContent = `${m.code} - ${m.name}`;
@@ -36,6 +64,34 @@ function popularMoedas(moedas) {
   para.value = 'BRL';
 }
 
+async function obterTaxa(de, para) {
+  try {
+    const response = await fetch(`${API_URL}/rates?source=${de}&target=${para}`, {
+      headers: API_KEY ? { Authorization: `Bearer ${API_KEY}` } : {},
+    });
+    if (!response.ok) throw new Error('Falha ao obter taxa');
+    const data = await response.json();
+    const taxa = Array.isArray(data) ? data[0]?.rate : data.rate;
+    if (!taxa) throw new Error('Taxa não encontrada');
+    return taxa;
+  } catch (error) {
+    console.warn('Falha ao obter taxa pela Wise, tentando fallback:', error);
+    const params = new URLSearchParams({ from: de, to: para });
+    const fallbackResponse = await fetch(
+      `https://api.exchangerate.host/convert?${params.toString()}`
+    );
+    if (!fallbackResponse.ok) {
+      throw new Error('Falha ao obter taxa de fallback');
+    }
+    const fallbackData = await fallbackResponse.json();
+    const taxaFallback = fallbackData?.info?.rate;
+    if (!taxaFallback) {
+      throw new Error('Taxa de fallback não encontrada');
+    }
+    return taxaFallback;
+  }
+}
+
 async function converter() {
   const valor = parseFloat(document.getElementById('amount').value);
   const de = document.getElementById('fromCurrency').value;
@@ -45,18 +101,13 @@ async function converter() {
     return;
   }
   try {
-    const response = await fetch(`${API_URL}/rates?source=${de}&target=${para}`, {
-      headers: API_KEY ? { Authorization: `Bearer ${API_KEY}` } : {},
-    });
-    if (!response.ok) throw new Error('Falha ao obter taxa');
-    const data = await response.json();
-    const taxa = Array.isArray(data) ? data[0]?.rate : data.rate;
-    if (!taxa) throw new Error('Taxa não encontrada');
+    const taxa = await obterTaxa(de, para);
     const convertido = (valor * taxa).toFixed(2);
     document.getElementById('result').textContent = `💰 ${convertido} ${para}`;
   } catch (error) {
     console.error('Erro na conversão:', error);
-    document.getElementById('result').textContent = 'Erro ao converter.';
+    document.getElementById('result').textContent =
+      'Erro ao converter. Tente novamente mais tarde.';
   }
 }
 


### PR DESCRIPTION
## Summary
- adicionar uma rotina dedicada para buscar a taxa da Wise com fallback automático
- integrar o serviço exchangerate.host como alternativa quando a API da Wise falhar
- aprimorar a mensagem exibida ao usuário quando nenhuma taxa puder ser obtida

## Testing
- node -e "new Function(require('fs').readFileSync('script.js','utf8'));"

------
https://chatgpt.com/codex/tasks/task_e_68d454cfc2b88327a61b438e34a7371c