### PR TITLE
Expandir fallback de moedas e documentar testes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Simple project developed with HTML, CSS and JavaScript to convert values between
 ## 📌 Features
 
 - Conversion of values using real-time rates from Wise.
-- Support for multiple currency pairs.
+- Support for multiple currency pairs, inclusive of dezenas de moedas populares do conversor da Wise mesmo sem acesso à API.
 - Minimalist and responsive interface.
 - 100% client-side and lightweight.
 
@@ -50,6 +50,14 @@ git clone https://github.com/christiandrades/conversor-peso-real.git
 ```
 2. Open the `index.html` file in your browser.
 3. Inform the amount and select the origin and destination currencies.
+
+### ✅ Testes automatizados
+
+Caso deseje garantir o comportamento do fallback sem depender das APIs externas, execute:
+
+```bash
+node tests/test.js
+```
 
 ---
 

--- a/script.js
+++ b/script.js
@@ -2,6 +2,72 @@ const API_URL = 'https://api.wise.com/v1';
 // Informe sua chave da Wise, se necessário
 const API_KEY = '';
 
+const FALLBACK_CURRENCIES = [
+  { code: 'AED', name: 'Dirham dos Emirados Árabes Unidos' },
+  { code: 'ARS', name: 'Peso Argentino' },
+  { code: 'AUD', name: 'Dólar Australiano' },
+  { code: 'BGN', name: 'Lev Búlgaro' },
+  { code: 'BHD', name: 'Dinar do Bahrein' },
+  { code: 'BOB', name: 'Boliviano da Bolívia' },
+  { code: 'BRL', name: 'Real Brasileiro' },
+  { code: 'CAD', name: 'Dólar Canadense' },
+  { code: 'CHF', name: 'Franco Suíço' },
+  { code: 'CLP', name: 'Peso Chileno' },
+  { code: 'CNY', name: 'Yuan Chinês' },
+  { code: 'COP', name: 'Peso Colombiano' },
+  { code: 'CRC', name: 'Colón Costarriquenho' },
+  { code: 'CZK', name: 'Coroa Checa' },
+  { code: 'DKK', name: 'Coroa Dinamarquesa' },
+  { code: 'DOP', name: 'Peso Dominicano' },
+  { code: 'EGP', name: 'Libra Egípcia' },
+  { code: 'EUR', name: 'Euro' },
+  { code: 'FJD', name: 'Dólar Fijiano' },
+  { code: 'GBP', name: 'Libra Esterlina' },
+  { code: 'GEL', name: 'Lari Georgiano' },
+  { code: 'GHS', name: 'Cedi Ganês' },
+  { code: 'HKD', name: 'Dólar de Hong Kong' },
+  { code: 'HRK', name: 'Kuna Croata' },
+  { code: 'HUF', name: 'Forint Húngaro' },
+  { code: 'IDR', name: 'Rupia Indonésia' },
+  { code: 'ILS', name: 'Novo Shekel Israelense' },
+  { code: 'INR', name: 'Rupia Indiana' },
+  { code: 'ISK', name: 'Coroa Islandesa' },
+  { code: 'JMD', name: 'Dólar Jamaicano' },
+  { code: 'JPY', name: 'Iene Japonês' },
+  { code: 'KES', name: 'Xelim Queniano' },
+  { code: 'KRW', name: 'Won Sul-Coreano' },
+  { code: 'KWD', name: 'Dinar Kuwaitiano' },
+  { code: 'LKR', name: 'Rupia do Sri Lanka' },
+  { code: 'MAD', name: 'Dirham Marroquino' },
+  { code: 'MXN', name: 'Peso Mexicano' },
+  { code: 'MYR', name: 'Ringgit Malaio' },
+  { code: 'NGN', name: 'Naira Nigeriana' },
+  { code: 'NOK', name: 'Coroa Norueguesa' },
+  { code: 'NZD', name: 'Dólar Neozelandês' },
+  { code: 'OMR', name: 'Rial Omanense' },
+  { code: 'PEN', name: 'Sol Peruano' },
+  { code: 'PHP', name: 'Peso Filipino' },
+  { code: 'PLN', name: 'Zloty Polonês' },
+  { code: 'PYG', name: 'Guarani Paraguaio' },
+  { code: 'QAR', name: 'Rial Catarense' },
+  { code: 'RON', name: 'Leu Romeno' },
+  { code: 'RSD', name: 'Dinar Sérvio' },
+  { code: 'SAR', name: 'Rial Saudita' },
+  { code: 'SEK', name: 'Coroa Sueca' },
+  { code: 'SGD', name: 'Dólar de Singapura' },
+  { code: 'THB', name: 'Baht Tailandês' },
+  { code: 'TND', name: 'Dinar Tunisiano' },
+  { code: 'TRY', name: 'Lira Turca' },
+  { code: 'TWD', name: 'Novo Dólar Taiwanês' },
+  { code: 'UAH', name: 'Hryvnia Ucraniana' },
+  { code: 'USD', name: 'Dólar Americano' },
+  { code: 'UYU', name: 'Peso Uruguaio' },
+  { code: 'VND', name: 'Dong Vietnamita' },
+  { code: 'XAF', name: 'Franco CFA da África Central' },
+  { code: 'XOF', name: 'Franco CFA da África Ocidental' },
+  { code: 'ZAR', name: 'Rand Sul-Africano' },
+];
+
 async function fetchCurrencies() {
   try {
     const response = await fetch(`${API_URL}/currencies`, {
@@ -11,20 +77,21 @@ async function fetchCurrencies() {
     return await response.json();
   } catch (error) {
     console.error('Erro ao buscar moedas:', error);
-    // Lista de fallback mínima
-    return [
-      { code: 'USD', name: 'US Dollar' },
-      { code: 'EUR', name: 'Euro' },
-      { code: 'BRL', name: 'Real Brasileiro' },
-      { code: 'CLP', name: 'Peso Chileno' },
-    ];
+    // Lista de fallback com moedas populares suportadas pela Wise
+    return FALLBACK_CURRENCIES;
   }
 }
 
 function popularMoedas(moedas) {
   const de = document.getElementById('fromCurrency');
   const para = document.getElementById('toCurrency');
-  moedas.forEach((m) => {
+  const listaOrdenada = [...moedas]
+    .filter((m) => m?.code && m?.name)
+    .sort((a, b) => a.code.localeCompare(b.code));
+
+  de.innerHTML = '';
+  para.innerHTML = '';
+  listaOrdenada.forEach((m) => {
     const opt = document.createElement('option');
     opt.value = m.code;
     opt.textContent = `${m.code} - ${m.name}`;
@@ -36,6 +103,34 @@ function popularMoedas(moedas) {
   para.value = 'BRL';
 }
 
+async function obterTaxa(de, para) {
+  try {
+    const response = await fetch(`${API_URL}/rates?source=${de}&target=${para}`, {
+      headers: API_KEY ? { Authorization: `Bearer ${API_KEY}` } : {},
+    });
+    if (!response.ok) throw new Error('Falha ao obter taxa');
+    const data = await response.json();
+    const taxa = Array.isArray(data) ? data[0]?.rate : data.rate;
+    if (!taxa) throw new Error('Taxa não encontrada');
+    return taxa;
+  } catch (error) {
+    console.warn('Falha ao obter taxa pela Wise, tentando fallback:', error);
+    const params = new URLSearchParams({ from: de, to: para });
+    const fallbackResponse = await fetch(
+      `https://api.exchangerate.host/convert?${params.toString()}`
+    );
+    if (!fallbackResponse.ok) {
+      throw new Error('Falha ao obter taxa de fallback');
+    }
+    const fallbackData = await fallbackResponse.json();
+    const taxaFallback = fallbackData?.info?.rate;
+    if (!taxaFallback) {
+      throw new Error('Taxa de fallback não encontrada');
+    }
+    return taxaFallback;
+  }
+}
+
 async function converter() {
   const valor = parseFloat(document.getElementById('amount').value);
   const de = document.getElementById('fromCurrency').value;
@@ -45,18 +140,13 @@ async function converter() {
     return;
   }
   try {
-    const response = await fetch(`${API_URL}/rates?source=${de}&target=${para}`, {
-      headers: API_KEY ? { Authorization: `Bearer ${API_KEY}` } : {},
-    });
-    if (!response.ok) throw new Error('Falha ao obter taxa');
-    const data = await response.json();
-    const taxa = Array.isArray(data) ? data[0]?.rate : data.rate;
-    if (!taxa) throw new Error('Taxa não encontrada');
+    const taxa = await obterTaxa(de, para);
     const convertido = (valor * taxa).toFixed(2);
     document.getElementById('result').textContent = `💰 ${convertido} ${para}`;
   } catch (error) {
     console.error('Erro na conversão:', error);
-    document.getElementById('result').textContent = 'Erro ao converter.';
+    document.getElementById('result').textContent =
+      'Erro ao converter. Tente novamente mais tarde.';
   }
 }
 
@@ -66,4 +156,17 @@ async function init() {
   document.getElementById('convert-btn').addEventListener('click', converter);
 }
 
-document.addEventListener('DOMContentLoaded', init);
+if (typeof document !== 'undefined' && document?.addEventListener) {
+  document.addEventListener('DOMContentLoaded', init);
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = {
+    fetchCurrencies,
+    popularMoedas,
+    obterTaxa,
+    converter,
+    init,
+    FALLBACK_CURRENCIES,
+  };
+}

--- a/tests/test.js
+++ b/tests/test.js
@@ -1,0 +1,59 @@
+const assert = require('assert').strict;
+const {
+  fetchCurrencies,
+  obterTaxa,
+} = require('../script.js');
+
+async function runFetchCurrenciesFallbackTest() {
+  const originalFetch = global.fetch;
+  try {
+    global.fetch = () => Promise.reject(new Error('network error'));
+    const currencies = await fetchCurrencies();
+    assert(Array.isArray(currencies), 'Lista de moedas deve ser um array');
+    assert(currencies.length > 0, 'Lista de fallback não pode estar vazia');
+    assert(
+      currencies.some((currency) => currency.code === 'USD'),
+      'Lista de fallback deve conter USD'
+    );
+  } finally {
+    global.fetch = originalFetch;
+  }
+}
+
+async function runObterTaxaFallbackTest() {
+  const originalFetch = global.fetch;
+  const calls = [];
+  try {
+    global.fetch = async (url, options) => {
+      calls.push({ url, options });
+      if (calls.length === 1) {
+        return { ok: false };
+      }
+      return {
+        ok: true,
+        json: async () => ({ info: { rate: 4.5 } }),
+      };
+    };
+    const rate = await obterTaxa('USD', 'BRL');
+    assert.strictEqual(rate, 4.5, 'Taxa de fallback deve ser utilizada');
+    assert(
+      calls[0].url.includes('/rates?source=USD&target=BRL'),
+      'Primeira chamada deve ser para a API da Wise'
+    );
+    assert(
+      calls[1].url.startsWith('https://api.exchangerate.host/convert?'),
+      'Segunda chamada deve ser para o serviço de fallback'
+    );
+  } finally {
+    global.fetch = originalFetch;
+  }
+}
+
+(async () => {
+  await runFetchCurrenciesFallbackTest();
+  await runObterTaxaFallbackTest();
+  console.log('Todos os testes passaram.');
+})().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- ampliar a lista local de moedas com dezenas de opções suportadas pela Wise para manter a experiência mesmo sem rede
- higienizar a renderização dos selects filtrando entradas inválidas e removendo duplicações ao repopular
- documentar no README o comando de testes automatizados que validam o fluxo de fallback

## Testing
- node tests/test.js

------
https://chatgpt.com/codex/tasks/task_e_68d454cfc2b88327a61b438e34a7371c